### PR TITLE
Fix/Object Pooling에 따른 EXPAttractController 버그 수정

### DIFF
--- a/Assets/Prefabs/EXP/EXP.prefab
+++ b/Assets/Prefabs/EXP/EXP.prefab
@@ -15,6 +15,8 @@ GameObject:
   - component: {fileID: 4219211734099544801}
   - component: {fileID: 7193640692225983248}
   - component: {fileID: 8102344605259037663}
+  - component: {fileID: 7141519888588494285}
+  - component: {fileID: 3014780811757040650}
   m_Layer: 0
   m_Name: EXP
   m_TagString: EXP
@@ -176,3 +178,29 @@ CapsuleCollider:
   m_Height: 1.9999999
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &7141519888588494285
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 350707820961524556}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3ce0f367f38dcf54081f74e6b872c380, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveSpeed: 0
+  moveDirection: {x: 0, y: 0, z: 0}
+--- !u!114 &3014780811757040650
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 350707820961524556}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 56a42675e79196b46b18eed91ea2a4d7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/Player/EXP/EXP.cs
+++ b/Assets/Scripts/Player/EXP/EXP.cs
@@ -8,6 +8,7 @@ public class EXP : MonoBehaviour
 
     private Renderer capsuleRenderer;       //캡슐 색
     private Rigidbody rb;
+    private Movement3D movement3D;
 
     private IObjectPool<GameObject> m_Pool;
 
@@ -15,6 +16,7 @@ public class EXP : MonoBehaviour
     {
         capsuleRenderer = GetComponent<Renderer>();
         rb = GetComponent<Rigidbody>();
+        movement3D = GetComponent<Movement3D>();
     }
 
     public void SetPool(IObjectPool<GameObject> pool)
@@ -35,8 +37,10 @@ public class EXP : MonoBehaviour
                 xPManager.AddExp(exp);
 
                 //경험치 옵젝 파괴(풀링 이용)
-                if(m_Pool != null)
+                if (m_Pool != null)
+                {
                     m_Pool.Release(gameObject);
+                }
                 else
                     Destroy(gameObject);
             }
@@ -48,5 +52,13 @@ public class EXP : MonoBehaviour
     {
         if (capsuleRenderer != null)
             capsuleRenderer.material.color = color;
+    }
+
+    private void OnDisable()
+    {
+        // 풀에 반환될 때 이전에 변경했던 상태들을 기본값으로 되돌립니다.
+        if (rb != null) rb.useGravity = true; 
+        if (movement3D != null) movement3D.MoveSpeed = 0;
+        gameObject.layer = LayerMask.NameToLayer("Default"); 
     }
 }

--- a/Assets/Scripts/Player/EXP/EXP.cs
+++ b/Assets/Scripts/Player/EXP/EXP.cs
@@ -8,7 +8,11 @@ public class EXP : MonoBehaviour
 
     private Renderer capsuleRenderer;       //Ä¸½¶ »ö
     private Rigidbody rb;
+    public Rigidbody Rb => rb;
     private Movement3D movement3D;
+    public Movement3D Movement3D => movement3D;
+    private MoveTo moveTo;
+    public MoveTo MoveTo => moveTo;
 
     private IObjectPool<GameObject> m_Pool;
 
@@ -17,6 +21,7 @@ public class EXP : MonoBehaviour
         capsuleRenderer = GetComponent<Renderer>();
         rb = GetComponent<Rigidbody>();
         movement3D = GetComponent<Movement3D>();
+        moveTo = GetComponent<MoveTo>();
     }
 
     public void SetPool(IObjectPool<GameObject> pool)

--- a/Assets/Scripts/Player/EXPAttractionController.cs
+++ b/Assets/Scripts/Player/EXPAttractionController.cs
@@ -7,7 +7,7 @@ public class EXPAttractionController : MonoBehaviour
 {
     [SerializeField]
     [Tooltip("경허치 구슬들이 플레이어로 딸려오는 속도")]
-    private float moveSpeed = 3.0f;
+    private float moveSpeed = 30.0f;
 
     //----------------------- Sphere - 플레이어 접촉 ------------------------
     private void OnTriggerEnter(Collider other)
@@ -28,8 +28,8 @@ public class EXPAttractionController : MonoBehaviour
                 //중력 off
                 capsuleGO.GetComponent<Rigidbody>().useGravity = false;
                 //플레이어를 향해 이동
-                capsuleGO.AddComponent<Movement3D>().MoveSpeed = moveSpeed;
-                var moveTo = capsuleGO.AddComponent<MoveTo>();
+                capsuleGO.GetComponent<Movement3D>().MoveSpeed = moveSpeed;
+                var moveTo = capsuleGO.GetComponent<MoveTo>();
                 moveTo.Setup(player);
             }
             Destroy(gameObject); // Sphere 오브젝트 자체를 파괴

--- a/Assets/Scripts/Player/EXPAttractionController.cs
+++ b/Assets/Scripts/Player/EXPAttractionController.cs
@@ -23,14 +23,15 @@ public class EXPAttractionController : MonoBehaviour
             var player = FindFirstObjectByType<FirstPersonCharacterController>().transform;
             foreach (GameObject capsuleGO in expCapsulesInScene)
             {
+                EXP eXP = capsuleGO.GetComponent<EXP>();
+
                 //충돌 끄기
                 capsuleGO.layer = LayerMask.NameToLayer("Noclip");
                 //중력 off
-                capsuleGO.GetComponent<Rigidbody>().useGravity = false;
+                eXP.Rb.useGravity = false;
                 //플레이어를 향해 이동
-                capsuleGO.GetComponent<Movement3D>().MoveSpeed = moveSpeed;
-                var moveTo = capsuleGO.GetComponent<MoveTo>();
-                moveTo.Setup(player);
+                eXP.Movement3D.MoveSpeed = moveSpeed;
+                eXP.MoveTo.Setup(player);
             }
             Destroy(gameObject); // Sphere 오브젝트 자체를 파괴
         }


### PR DESCRIPTION
#### PR Classification
Object Pooling 적용 이후 새로 드랍된 EXP 캡슐이 플레이어에게 따라오는 현상 수정

#### PR Summary
주요 변경 사항
- EXP.prefab: Movement3D와 MoveTo 를 동적 부착 하는 대신 미리 부착
- EXP.cs: `Movement3D` 컴포넌트 추가 및 `Awake` 메서드에서 초기화 코드 추가.
- EXP.cs: `OnDisable` 메서드 추가로 비활성화 시 동작 정의.
- EXPAttractionController.cs: `moveSpeed` 기본값을 3.0f에서 30.0f로 변경.
